### PR TITLE
fix(92-strict-scan): added gitleaks configuration for low entropy

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,38 +1,40 @@
 # Software Composition Analysis (SCA) Workflow
 #
-# This workflow performs automated security scanning of project dependencies to identify
-# vulnerabilities, license issues, and outdated packages.
+# This workflow performs security scanning of software dependencies and components.
+# It runs on multiple triggers to ensure comprehensive coverage of dependency security.
 #
 # Triggers:
-#   - schedule: Runs daily at midnight (00:00 UTC)
-#   - pull_request: Executes when PRs are opened against the main branch
-#   - workflow_dispatch: Allows manual workflow execution
+#   - schedule: Daily at midnight UTC (cron: "0 0 * * *")
+#   - pull_request: When PRs are opened/updated targeting the main branch
+#   - push: When code is pushed to the main branch
+#   - workflow_dispatch: Manual trigger via GitHub UI
+#   - branch_protection_rule: When branch protection rules are modified
 #
-# Jobs:
-#   1. setup: Initializes workflow environment configuration
-#      - Sets the environment variable to 'base'
-#      - Outputs environment name for downstream jobs
+# Permissions:
+#   - contents: write - Required to access repository contents and create commits
+#   - pull-requests: write - Required to comment on PRs with scan results
+#   - issues: write - Required to create/update security issues
+#   - security-events: write - Required to upload security scan results to GitHub Security
+#   - id-token: write - Required for OIDC authentication
+#   - actions: read - Required to read workflow run information
 #
-#   2. sca: Executes the Software Composition Analysis
-#      - Permissions:
-#        * contents: write - For creating/updating files
-#        * pull-requests: write - For PR comments and updates
-#        * issues: write - For creating security issues
-#        * security-events: read - For accessing security scan results
-#      - Uses MoJ's devsecops-actions/sca action (v1.1.0)
-#      - Configuration:
-#        * Authenticates using GitHub token
-#        * Uses custom dependency review config from .github/dependency-review-config.yml
-#      - Depends on successful completion of setup job
-#      - Runs in the environment specified by setup job output
+# Steps:
+#   1. Repository: Checks out the repository code
+#   2. Node: Sets up Node.js environment using the version from repository variables
+#   3. Install: Installs npm dependencies without running scripts for security
+#   4. SCA: Executes the Software Composition Analysis using MoJ's DevSecOps action
+#      - Uses GitHub token for authentication
+#      - References custom dependency review configuration
+#      - Scans Docker images listed in sources.json
 #
-# Environment:
-#   - Default environment: base
+# Dependencies:
+#   - actions/checkout@v6.0.1
+#   - actions/setup-node@v6.1.0
+#   - ministryofjustice/devsecops-actions/sca@v1.2.0
 #
-# Security:
-#   - Workflow has minimal default permissions (none)
-#   - Individual jobs specify required granular permissions
-#   - Uses pinned action version with SHA for supply chain security
+# Configuration Files:
+#   - .github/dependency-review-config.yml: Custom dependency review rules
+#   - sources.json: List of Docker images to scan
 
 name: SCA ⚡️
 run-name: Software Composition Analysis ⚡️
@@ -44,41 +46,41 @@ on:
   pull_request:
     branches: ["main"]
 
+  push:
+    branches: ["main"]
+
   workflow_dispatch:
+  branch_protection_rule:
 
 permissions: {}
 
-env:
-  environment: base
-
 jobs:
-  # 1. Pre-requisite
-  setup:
-    name: Setup 🔧
-    runs-on: ["ubuntu-latest"]
-    outputs:
-      environment: ${{ env.environment }}
-    steps:
-      - name: Environment 🧪
-        run: echo "Environment set to ${{ env.environment }}"
-
-  # 2. MoJ - SCA
   sca:
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      security-events: read
+      security-events: write
+      id-token: write
+      actions: read
 
     name: Execute ⚙️
     runs-on: ["ubuntu-latest"]
-    needs: setup
-    environment:
-      name: ${{ needs.setup.outputs.environment }}
 
     steps:
-      - name: SCA
+      - name: Repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # frozen: v6.0.1
+
+      - name: Node
+        uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # frozen: v6.1.0
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+
+      - name: Install
+        run: npm ci --ignore-scripts
+
+      - name: ⚡️ SCA
         uses: ministryofjustice/devsecops-actions/sca@c210b12f1bd77564cee5c5f5c7306cd63dc89867 # frozen: v1.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          dependency-review-config-file: "./.github/dependency-review-config.yml"
+          token: ${{ secrets.GITHUB_TOKEN }} # Mandatory
+          dependency-review-config-file: "./.github/dependency-review-config.yml" # Optional

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+title = "Strict secret detection"
+
+[[rules]]
+id = "generic-password"
+description = "Generic passwords"
+regex = '''(?i)(password|passwd|pwd)\s*[:=]\s*["']?[^"'\\s]+["']?'''
+entropy = 3.0
+
+[[rules]]
+id = "generic-secret"
+description = "Generic secrets"
+regex = '''(?i)(secret|client_secret|private_key)\s*[:=]\s*["']?[^"'\\s]+["']?'''
+entropy = 3.0
+
+[[rules]]
+id = "api-key"
+description = "Generic API keys"
+regex = '''(?i)(api[_-]?key|access[_-]?key)\s*[:=]\s*["']?[A-Za-z0-9_\-]{8,}["']?'''
+entropy = 3.0
+
+[[rules]]
+id = "token"
+description = "Generic authentication tokens"
+regex = '''(?i)(token|auth[_-]?token|bearer)\s*[:=]\s*["']?[A-Za-z0-9\-_\.]{8,}["']?'''
+entropy = 3.0
+
+[[rules]]
+id = "username-password-combo"
+description = "Generic credentials"
+regex = '''(?i)(user(name)?\s*[:=].+password\s*[:=].+)'''
+entropy = 3.0
+
+[[rules]]
+id = "private-key-block"
+description = "Generic encryption keys"
+regex = '''-----BEGIN (RSA|EC|DSA|OPENSSH|PGP) PRIVATE KEY-----'''
+entropy = 3.0
+
+[allowlist]
+paths = ["node_modules/*"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@cspell/dict-companies": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.9.tgz",
-      "integrity": "sha512-y5GdU+LnuMhUE/WYwOYt7GcJdrpmV4KXE1oFb5toEsnGa2KzffUbS6lwPpeRBocQoqZj8jJYFtxoQ+2KVg++/A==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.10.tgz",
+      "integrity": "sha512-bJ1qnO1DkTn7JYGXvxp8FRQc4yq6tRXnrII+jbP8hHmq5TX5o1Wu+rdfpoUQaMWTl6balRvcMYiINDesnpR9Bw==",
       "dev": true,
       "license": "MIT"
     },
@@ -236,9 +236,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-dotnet": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.10.tgz",
-      "integrity": "sha512-ooar8BP/RBNP1gzYfJPStKEmpWy4uv/7JCq6FOnJLeD1yyfG3d/LFMVMwiJo+XWz025cxtkM3wuaikBWzCqkmg==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.11.tgz",
+      "integrity": "sha512-LSVKhpFf/ASTWJcfYeS0Sykcl1gVMsv2Z5Eo0TnTMSTLV3738HH+66pIsjUTChqU6SF3gKPuCe6EOaRYqb/evA==",
       "dev": true,
       "license": "MIT"
     },
@@ -250,23 +250,23 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.26.tgz",
-      "integrity": "sha512-rpjM87n2e3PN3mx9SbzQOIniEWUKewZj0xFA796Pzeu3gJlYsHsSkZZC6Jxdea2992EfrzJZYwJb+mjxa3gWGg==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.27.tgz",
+      "integrity": "sha512-0y4vH2i5cFmi8sxkc4OlD2IlnqDznOtKczm4h6jA288g5VVrm3bhkYK6vcB8b0CoRKtYWKet4VEmHBP1yI+Qfw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.10.tgz",
-      "integrity": "sha512-+S10oo15G3Axz1W4FGmYNq9u0xxS6OhNl9dXY3qjYBOqhzfF3l1oM/TpkfH/1NH31r3GneuPVXKXT7y16qwJYA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.11.tgz",
+      "integrity": "sha512-2jcY494If1udvzd7MT2z/QH/RACUo/I02vIY4ttNdZhgYvUmRKhg8OBdrbzYo0lJOcc7XUb8rhIFQRHzxOSVeA==",
       "dev": true,
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.15.tgz",
-      "integrity": "sha512-iF1KPSULjpAbtmPFTzyykytQPliBw5Qc7EVt5a/cdpJ/WBnosjBKHj0/svESc+enQoxq7bMcmhL9qJeGHQAWyQ==",
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.16.tgz",
+      "integrity": "sha512-4PPdapCJslytxAVJu35Mv97qDyGmAQxtDE790T2bWNhcqN6gvRVAc/eTRaXkUIf21q1xCxxNNqpH4VfMup69rQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -320,9 +320,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.25.tgz",
-      "integrity": "sha512-Q0mkUj1mFN1P5LZoKBeTLOQehlHMYv62K0Px9FS7qykSvZjBz44bhCezJuepTPCiCFqmwQgT2fc3Ixw+fhO6pQ==",
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
+      "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
       "dev": true,
       "license": "MIT"
     },
@@ -438,16 +438,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.27",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.27.tgz",
-      "integrity": "sha512-REy2vRQ9BJkjoW8cEr8ewoJAZ0DsTh+TimJ58KgIG1d81caanNgdvKLSgDkPd8OlGxPfLKHe7o2TJuk/l7VqhA==",
+      "version": "5.2.29",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.29.tgz",
+      "integrity": "sha512-ZAef8JpYmbuHFT1zekj/YyImLPvZevjECw663EmG5GPePyNo4AfH8Dd2fFhaOyQ3P5I5LrkAhGwypnOfUxcssw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-php": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.0.tgz",
-      "integrity": "sha512-dTDeabyOj7eFvn2Q4Za3uVXM2+SzeFMqX8ly2P0XTo4AzbCmI2hulFD/QIADwWmwiRrInbbf8cxwFHNIYrXl4w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.1.tgz",
+      "integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA==",
       "dev": true,
       "license": "MIT"
     },
@@ -466,9 +466,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.24",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.24.tgz",
-      "integrity": "sha512-B1oXYTa0+3sKOvx/svwxFaT3MrkHJ7ZLWpA1N7ZyHoET7IJhLCwcfAu7DCTq1f24Wnd4t+ARJvPEmFbMx65VBw==",
+      "version": "4.2.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.25.tgz",
+      "integrity": "sha512-hDdN0YhKgpbtZVRjQ2c8jk+n0wQdidAKj1Fk8w7KEHb3YlY5uPJ0mAKJk7AJKPNLOlILoUmN+HAVJz+cfSbWYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -483,23 +483,23 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.9.tgz",
-      "integrity": "sha512-H2vMcERMcANvQshAdrVx0XoWaNX8zmmiQN11dZZTQAZaNJ0xatdJoSqY8C8uhEMW89bfgpN+NQgGuDXW2vmXEw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.0.tgz",
+      "integrity": "sha512-9PJQB3cfkBULrMLp5kSAcFPpzf8oz9vFN+QYZABhQwWkGbuzCIXSorHrmWSASlx4yejt3brjaWS57zZ/YL5ZQQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-rust": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.0.tgz",
-      "integrity": "sha512-ysFxxKc3QjPWtPacbwxzz8sDOACHNShlhQpnBsDXAHN3LogmuBsQtfyuU30APqFjCOg9KwGciKYC/hcGxJCbiA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.1.tgz",
+      "integrity": "sha512-fXiXnZH0wOaEVTKFRNaz6TsUGhuB8dAT0ubYkDNzRQCaV5JGSOebGb1v2x5ZrOSVp+moxWM/vdBfiNU6KOEaFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-scala": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.8.tgz",
-      "integrity": "sha512-YdftVmumv8IZq9zu1gn2U7A4bfM2yj9Vaupydotyjuc+EEZZSqAafTpvW/jKLWji2TgybM1L2IhmV0s/Iv9BTw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.9.tgz",
+      "integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg==",
       "dev": true,
       "license": "MIT"
     },
@@ -511,9 +511,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.1.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.18.tgz",
-      "integrity": "sha512-+RUM+DnRnGzDjnJrAEiEQnopPGBXQ5kUY9t38WdTVYVgkpIE0/dcMX+s5uAp7vvKezhU6gW+CGW5K5xdF2KKiw==",
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.20.tgz",
+      "integrity": "sha512-TEk1xHvetTI4pv7Vzje1D322m6QEjaH2P6ucOOf6q7EJCppQIdC0lZSXkgHJAFU5HGSvEXSzvnVeW2RHW86ziQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@types/katex": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
-      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
# Introduction :pencil2:

Ensure the repository has low entropy threshold for scanning credentials.

## Resolution :heavy_check_mark:

* Added a custom configuration file `.gitleaks.toml` for GitLeaks to detect generic credentials, keys, tokens and secrets with lower entropy of `2.0` (this does increases the risk of high false-positive).
* Ensured `node_modules` is allowed, therefore ignoring any secrets in the directory.

## Miscellaneous :heavy_plus_sign:

* Dependency updates
* Updated `sca.yml` workflow.

