### PR TITLE
feat(125-min-age): added cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,11 @@ updates:
     schedule:
       interval: "daily"
       time: "00:00"
+    cooldown:
+      default-days: 3
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: ":dependabot: NPM"
       include: "scope"
@@ -47,6 +52,28 @@ updates:
       - "chore"
     groups:
       npm-packages:
+        patterns:
+          - "*"
+    assignees:
+      - "dev-sec-ops"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    cooldown:
+      default-days: 3
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    commit-message:
+      prefix: ":dependabot: PIP"
+      include: "scope"
+    labels:
+      - "chore"
+    groups:
+      pip-packages:
         patterns:
           - "*"
     assignees:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "MIT",
       "devDependencies": {
         "bats": "^1.13.0",
-        "cspell": "^9.6.0",
+        "cspell": "^9.6.2",
         "markdownlint-cli": "^0.47.0",
-        "sort-package-json": "^3.6.0",
+        "sort-package-json": "^3.6.1",
         "yaml-lint": "^1.7.0"
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.6.0.tgz",
-      "integrity": "sha512-gLNe9bB+5gMsTEhR9YPE0Wt122HR2EV+Q1j9W+MbwbeBJmpTWrgAP1ZdpvHOg+6LF6x/bD/EC9HfWdd/om8wXA==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.6.2.tgz",
+      "integrity": "sha512-s5u/3nhQUftKibPIbRLLAf4M5JG1NykqkPCxS0STMmri0hzVMZbAOCyHjdLoOCqPUn0xZzLA8fgeYg3b7QuHpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -39,15 +39,15 @@
         "@cspell/dict-dotnet": "^5.0.11",
         "@cspell/dict-elixir": "^4.0.8",
         "@cspell/dict-en_us": "^4.4.27",
-        "@cspell/dict-en-common-misspellings": "^2.1.11",
+        "@cspell/dict-en-common-misspellings": "^2.1.12",
         "@cspell/dict-en-gb-mit": "^3.1.16",
         "@cspell/dict-filetypes": "^3.0.15",
         "@cspell/dict-flutter": "^1.1.1",
         "@cspell/dict-fonts": "^4.0.5",
         "@cspell/dict-fsharp": "^1.1.1",
-        "@cspell/dict-fullstack": "^3.2.7",
+        "@cspell/dict-fullstack": "^3.2.8",
         "@cspell/dict-gaming-terms": "^1.1.2",
-        "@cspell/dict-git": "^3.0.7",
+        "@cspell/dict-git": "^3.1.0",
         "@cspell/dict-golang": "^6.0.26",
         "@cspell/dict-google": "^1.0.9",
         "@cspell/dict-haskell": "^4.0.6",
@@ -57,14 +57,14 @@
         "@cspell/dict-julia": "^1.1.1",
         "@cspell/dict-k8s": "^1.0.12",
         "@cspell/dict-kotlin": "^1.1.1",
-        "@cspell/dict-latex": "^4.0.4",
+        "@cspell/dict-latex": "^5.0.0",
         "@cspell/dict-lorem-ipsum": "^4.0.5",
         "@cspell/dict-lua": "^4.0.8",
         "@cspell/dict-makefile": "^1.0.5",
         "@cspell/dict-markdown": "^2.0.14",
         "@cspell/dict-monkeyc": "^1.0.12",
-        "@cspell/dict-node": "^5.0.8",
-        "@cspell/dict-npm": "^5.2.29",
+        "@cspell/dict-node": "^5.0.9",
+        "@cspell/dict-npm": "^5.2.31",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
         "@cspell/dict-public-licenses": "^2.0.15",
@@ -88,22 +88,32 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.6.0.tgz",
-      "integrity": "sha512-5sY1lgAXS5xEOsjT5rREMADj7pHIt56XOL7xR80nNl0TwlpZbeBHhoB2aH5sirVTeodJFN5iraXNbVOYPPupPw==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.6.2.tgz",
+      "integrity": "sha512-8TCD7KOG9ppo5BoJOe2diACfB6I6UpJmYmjLOxMy0o8y3ruWFoDKaDEsf5tIi4T7cdVb8MjGbHjw9ksCwRRMjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.6.0"
+        "@cspell/cspell-types": "9.6.2"
       },
       "engines": {
         "node": ">=20"
       }
     },
+    "node_modules/@cspell/cspell-performance-monitor": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.6.2.tgz",
+      "integrity": "sha512-MZuhYy59zFCVsX3PzW02/3TqPsPw87MELOJuZfpWDcGgxrweTrVjMdmJ0/w7COJ6zEAqtgGjNMAEmK4xJnrQjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18"
+      }
+    },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.6.0.tgz",
-      "integrity": "sha512-YNuY8NNXfE+8Qzknm2ps6QbrZLZu6rSZTZr3dYW3K6TK7+IFVlJ6e2Z9iKJTqp6aZ4AGU/r9QYGmNX4Oq4gZ0A==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.6.2.tgz",
+      "integrity": "sha512-Wt6Cf4b/E0QJ/TkbOMjXSGrccASgbc8xZq3c+8+kCXM5JT92NP2Lx67m3UA1g+BDv7E4DNPuwm1fM7o/2zum5w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -111,9 +121,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.6.0.tgz",
-      "integrity": "sha512-Gb2UWNmRpTOQGpYL4Q/LMw+b50KcRZcf/wJg6w0Yl3IT+F/uDNhNh1f5rHuTyGsbMsMxHJhsb2AoP+73GlbIfw==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.6.2.tgz",
+      "integrity": "sha512-u7P4ErApEcSP+Si2HaeotFQXjuCopAa+wPF1fDzuJzpotPxsDwNDanGGn2qUMjOyVI4UiI84MPI6ZuGLj5EDyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -124,9 +134,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.6.0.tgz",
-      "integrity": "sha512-DCuKKkySTEB8MPLTdoPMdmakYcx7XCsHz1YEMbzOcLqJCxXsRlRZg4qE9kRBee/2QY7eYA2kaYNgn/TDMooa4g==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.6.2.tgz",
+      "integrity": "sha512-T4LBWe3NYpKPD/fIkYAL56z5pr8Cgh//UZDl4afDTJNuTkdE6ZL93MBAUXggONHqY8B9dRXlQKrD4PD+kHabtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -134,13 +144,26 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.6.0.tgz",
-      "integrity": "sha512-JTqrD47tV+rWc1y2W8T0NTfWLQMlSWX4OF64/Jf3WbsOD+4UXVIfjRlzPry7+1Zekm6pa38+23jkDBytYpu8yw==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-9.6.2.tgz",
+      "integrity": "sha512-RsUFrSB0oQHEBnR8yarKIReUPwSu2ROpbjhdVKi4T/nQhMaS+TnIQPBwkMtb2r8A1KS2Hijw4D/4bV/XHoFQWw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@cspell/cspell-worker": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.6.2.tgz",
+      "integrity": "sha512-1xq8jmt6YZ7MVPESydjYJ3p67vi+YWgi5qow1xyZzeQWFXVCCFi9pQSxC0bzGQwWrYGNWSAIbYZB3Sq5ntYz4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cspell-lib": "9.6.2"
+      },
+      "engines": {
+        "node": ">=20.18"
       }
     },
     "node_modules/@cspell/dict-ada": {
@@ -259,9 +282,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.11.tgz",
-      "integrity": "sha512-2jcY494If1udvzd7MT2z/QH/RACUo/I02vIY4ttNdZhgYvUmRKhg8OBdrbzYo0lJOcc7XUb8rhIFQRHzxOSVeA==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.12.tgz",
+      "integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw==",
       "dev": true,
       "license": "CC BY-SA 4.0"
     },
@@ -301,9 +324,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.7.tgz",
-      "integrity": "sha512-IxEk2YAwAJKYCUEgEeOg3QvTL4XLlyArJElFuMQevU1dPgHgzWElFevN5lsTFnvMFA1riYsVinqJJX0BanCFEg==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.8.tgz",
+      "integrity": "sha512-J6EeoeThvx/DFrcA2rJiCA6vfqwJMbkG0IcXhlsmRZmasIpanmxgt90OEaUazbZahFiuJT8wrhgQ1QgD1MsqBw==",
       "dev": true,
       "license": "MIT"
     },
@@ -315,9 +338,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-git": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.7.tgz",
-      "integrity": "sha512-odOwVKgfxCQfiSb+nblQZc4ErXmnWEnv8XwkaI4sNJ7cNmojnvogYVeMqkXPjvfrgEcizEEA4URRD2Ms5PDk1w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.1.0.tgz",
+      "integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -385,9 +408,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-latex": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.4.tgz",
-      "integrity": "sha512-YdTQhnTINEEm/LZgTzr9Voz4mzdOXH7YX+bSFs3hnkUHCUUtX/mhKgf1CFvZ0YNM2afjhQcmLaR9bDQVyYBvpA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-5.0.0.tgz",
+      "integrity": "sha512-HUrIqUVohM6P0+5b7BsdAdb0STIv0aaFBvguI7pLcreljlcX3FSPUxea7ticzNlCNeVrEaiEn/ws9m6rYUeuNw==",
       "dev": true,
       "license": "MIT"
     },
@@ -433,16 +456,16 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-node": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.8.tgz",
-      "integrity": "sha512-AirZcN2i84ynev3p2/1NCPEhnNsHKMz9zciTngGoqpdItUb2bDt1nJBjwlsrFI78GZRph/VaqTVFwYikmncpXg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.9.tgz",
+      "integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.29",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.29.tgz",
-      "integrity": "sha512-ZAef8JpYmbuHFT1zekj/YyImLPvZevjECw663EmG5GPePyNo4AfH8Dd2fFhaOyQ3P5I5LrkAhGwypnOfUxcssw==",
+      "version": "5.2.31",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.31.tgz",
+      "integrity": "sha512-+HoFoFe53pL0wDuSHRs5L+CcDMaG5sLfjKLPT4H0VdwNzho3HLOohTCZr6cYt7OEbXf3xi4YXBkamCy38xOpjA==",
       "dev": true,
       "license": "MIT"
     },
@@ -569,13 +592,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.6.0.tgz",
-      "integrity": "sha512-Lkn82wyGj2ltxeYfH2bEjshdes1fx3ouYUZxeW5i6SBBvEVJoSmr43AygI8A317UMIQxVj59qVBorrtGYcRI1w==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.6.2.tgz",
+      "integrity": "sha512-DY/X6lsdK4aeJ4erPVZoU1ccEXqtnYqWCMUXZOsMeIsZlXwZz/ocNNd09A4ga9IzGj1lYsB13UG4GVe8lSMAXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.6.0",
+        "@cspell/url": "9.6.2",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
@@ -583,9 +606,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.6.0.tgz",
-      "integrity": "sha512-CaWyk5j20H6sr+HCArtUY95jUQb7A/6W0GC4B4umnqoWvgqwR72duowLFa+w1K2C7tZg3GoV4Wf2cUn9jjt5FA==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.6.2.tgz",
+      "integrity": "sha512-XYAuGZoRCUf4Y12YP+K0BpU3QUMj4Z4SkKpi08Dwx/bQlq/NqycHKkUWYhlViHLav1+MJbWxcvDIHxGNv0UIaA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -593,9 +616,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.6.0.tgz",
-      "integrity": "sha512-9g8LCLv/2RrprGeGnFAaBETWq7ESnBcoMbvgNu+vZE58iF+pbFvP0qGgKvVeKEEpc2LZhNuHLsUH37MUS6DOQg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.6.2.tgz",
+      "integrity": "sha512-7zpnLkpT91wsH4aU3oAprnzrURvBWKq97j5i/SWXGuNKf36XNEO4HaeaPp6L2oVq4OzdUOdm0tUK1gB0HhMWSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -603,9 +626,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.6.0.tgz",
-      "integrity": "sha512-257WOxh9vOYHAVgBNXRCdLEd+ldzlVbzcc9u+6DYoCDCNGe0OvOWOGsAfnUbMc9xEw48XgBlDYgOlPbjWGLOTg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.6.2.tgz",
+      "integrity": "sha512-625EiP1jUOQZ6UQuTUV1XB8Bxa18z3EtC1qA6PJyM3TqUD8PD8Tz183j9av6d/Dq52+7w0F4ovuqjUcTXTfD6g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -986,27 +1009,29 @@
       "license": "MIT"
     },
     "node_modules/cspell": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.6.0.tgz",
-      "integrity": "sha512-Mpf0oT2KAHTIb3YPAXWhW64/4CZKW5Lka4j1YxCLK3jM3nenmIsY/ocrJvqCMF4+1eejRF0N55sT3XmrijI5YQ==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.6.2.tgz",
+      "integrity": "sha512-EmkSGhStMbSh2BcyMqbVDOF48fSPWL3adjqajUVCwfnlZD7mzUWPx9pR8pt2dOQaFEE47rlOQGXdd3wTqL5dnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "9.6.0",
-        "@cspell/cspell-pipe": "9.6.0",
-        "@cspell/cspell-types": "9.6.0",
-        "@cspell/dynamic-import": "9.6.0",
-        "@cspell/url": "9.6.0",
+        "@cspell/cspell-json-reporter": "9.6.2",
+        "@cspell/cspell-performance-monitor": "9.6.2",
+        "@cspell/cspell-pipe": "9.6.2",
+        "@cspell/cspell-types": "9.6.2",
+        "@cspell/cspell-worker": "9.6.2",
+        "@cspell/dynamic-import": "9.6.2",
+        "@cspell/url": "9.6.2",
         "ansi-regex": "^6.2.2",
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "commander": "^14.0.2",
-        "cspell-config-lib": "9.6.0",
-        "cspell-dictionary": "9.6.0",
-        "cspell-gitignore": "9.6.0",
-        "cspell-glob": "9.6.0",
-        "cspell-io": "9.6.0",
-        "cspell-lib": "9.6.0",
+        "cspell-config-lib": "9.6.2",
+        "cspell-dictionary": "9.6.2",
+        "cspell-gitignore": "9.6.2",
+        "cspell-glob": "9.6.2",
+        "cspell-io": "9.6.2",
+        "cspell-lib": "9.6.2",
         "fast-json-stable-stringify": "^2.1.0",
         "flatted": "^3.3.3",
         "semver": "^7.7.3",
@@ -1017,20 +1042,20 @@
         "cspell-esm": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18"
       },
       "funding": {
         "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.6.0.tgz",
-      "integrity": "sha512-5ztvheawkmFXNHGN82iOOntU3T5mmlQBP/plgoKdBZ6+lSYrOJLkOyqxYyi7MrUBDtWrXPzFllkBrPNRDlbX/A==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.6.2.tgz",
+      "integrity": "sha512-VQB+xmqGqCJrt5k/o0rRG9v0X0CA96CEd9FsmBAm5+9DvNiRzXOqewZSdsOM2Y0SX7YKcvG82PfRsujhYltcfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "9.6.0",
+        "@cspell/cspell-types": "9.6.2",
         "comment-json": "^4.5.1",
         "smol-toml": "^1.6.0",
         "yaml": "^2.8.2"
@@ -1040,15 +1065,16 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.6.0.tgz",
-      "integrity": "sha512-wW0m1kLrbK6bRY/GrLUGKUUJ1Z4ZUgIb8LD4zNaECcvGviv9V7VcR3mEwUip3ZjoHa3ClzEoWgQ9gXrtac80Wg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.6.2.tgz",
+      "integrity": "sha512-J55/9+AtkRzfSVn+KaqoWxsS4O66szKP6LrDW0O2qWnuvVvO1BoAMsINynD845IIzrd1n1yTOHS/DbjmHd4//A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.6.0",
-        "@cspell/cspell-types": "9.6.0",
-        "cspell-trie-lib": "9.6.0",
+        "@cspell/cspell-performance-monitor": "9.6.2",
+        "@cspell/cspell-pipe": "9.6.2",
+        "@cspell/cspell-types": "9.6.2",
+        "cspell-trie-lib": "9.6.2",
         "fast-equals": "^6.0.0"
       },
       "engines": {
@@ -1056,15 +1082,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.6.0.tgz",
-      "integrity": "sha512-8GfmJuRBBvibyPHnNE2wYJAiQ/ceDYLD1X1sUQaCyj6hPMR7ChJiVhFPtS11hMqkjZ46OBMYTMGWqO792L9fEQ==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.6.2.tgz",
+      "integrity": "sha512-vtwc9AAA9m3aZPtbvPPRTLXIqwryljxEgQTkpr92mFZaGftvnLfNVb2z++NvWbXq9azGKN/7oiLjecb9dhYnfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.6.0",
-        "cspell-glob": "9.6.0",
-        "cspell-io": "9.6.0"
+        "@cspell/url": "9.6.2",
+        "cspell-glob": "9.6.2",
+        "cspell-io": "9.6.2"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -1074,13 +1100,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.6.0.tgz",
-      "integrity": "sha512-KmEbKN0qdEamsEYbkFu7zjLYfw3hMmn9kmeh94IHr2kq6vWq5vNP5l1BuqmrUeFZlbNd07vj08IKAZHYsoGheQ==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.6.2.tgz",
+      "integrity": "sha512-5j+g4JzcWjW16ZAtcPHpG138CEfpp1YmuYJoYtze3lIZLgttt+k2gXJsqyWaP/6MdVknI0Q1afGSKYRtH8mLRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "9.6.0",
+        "@cspell/url": "9.6.2",
         "picomatch": "^4.0.3"
       },
       "engines": {
@@ -1088,14 +1114,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.6.0.tgz",
-      "integrity": "sha512-jZVIM5/3eB9rWURDq+VXdYip+DmPuFzO+bqaRtzqT8w6YoOIGYbiIxdwvyyA9xdH7SmW8uqHJP5x4pzZju1lNQ==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.6.2.tgz",
+      "integrity": "sha512-JTH92+1VGFPb3UsDT+Ezur/ouR8t+XOZkETUkk8eoSBzli9hWgPHW7kl2T8Chcn+Dq/6FLlvezYbBvhSauqJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "9.6.0",
-        "@cspell/cspell-types": "9.6.0"
+        "@cspell/cspell-pipe": "9.6.2",
+        "@cspell/cspell-types": "9.6.2"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -1105,41 +1131,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.6.0.tgz",
-      "integrity": "sha512-wZuZzKOYIb698kVEINYjGaNFQu+AFZ945TORM3hapmPjez+vsHwl8m/pPpCHeGMpQtHMEDkX84AbQ7R55MRIwg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.6.2.tgz",
+      "integrity": "sha512-VRBkAfUdbaq5yDYoVMvodQF3bIdBL6Gy4tiMvf+UI9C16am47AuThg1gGXRzwi5hCEXnCfevAmuVdaQP3onkow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "9.6.0",
-        "@cspell/url": "9.6.0"
+        "@cspell/cspell-service-bus": "9.6.2",
+        "@cspell/url": "9.6.2"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.6.0.tgz",
-      "integrity": "sha512-m9rIv8hkQ3Dio4s80HQbM9cdxENcd6pS8j2AHWL50OSjJf3Xhw6/wMrIAGbwLHP15K6QZVU2eJ/abCzIJwjA4w==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.6.2.tgz",
+      "integrity": "sha512-LvValIwqDAwVp2Www+7PPJ7UbVurYtKGPddpGH7GN+0u+UWzR4oUXR80gY8lHgSrIQ3EkdLhFAItPcyMjGjzIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "9.6.0",
-        "@cspell/cspell-pipe": "9.6.0",
-        "@cspell/cspell-resolver": "9.6.0",
-        "@cspell/cspell-types": "9.6.0",
-        "@cspell/dynamic-import": "9.6.0",
-        "@cspell/filetypes": "9.6.0",
-        "@cspell/strong-weak-map": "9.6.0",
-        "@cspell/url": "9.6.0",
+        "@cspell/cspell-bundled-dicts": "9.6.2",
+        "@cspell/cspell-performance-monitor": "9.6.2",
+        "@cspell/cspell-pipe": "9.6.2",
+        "@cspell/cspell-resolver": "9.6.2",
+        "@cspell/cspell-types": "9.6.2",
+        "@cspell/dynamic-import": "9.6.2",
+        "@cspell/filetypes": "9.6.2",
+        "@cspell/strong-weak-map": "9.6.2",
+        "@cspell/url": "9.6.2",
         "clear-module": "^4.1.2",
-        "cspell-config-lib": "9.6.0",
-        "cspell-dictionary": "9.6.0",
-        "cspell-glob": "9.6.0",
-        "cspell-grammar": "9.6.0",
-        "cspell-io": "9.6.0",
-        "cspell-trie-lib": "9.6.0",
+        "cspell-config-lib": "9.6.2",
+        "cspell-dictionary": "9.6.2",
+        "cspell-glob": "9.6.2",
+        "cspell-grammar": "9.6.2",
+        "cspell-io": "9.6.2",
+        "cspell-trie-lib": "9.6.2",
         "env-paths": "^3.0.0",
         "gensequence": "^8.0.8",
         "import-fresh": "^3.3.1",
@@ -1153,16 +1180,16 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.6.0.tgz",
-      "integrity": "sha512-L7GSff5F9cF60QT78WsebVlb3sppi6jbvTHwsw7WF1jUN/ioAo7OzBYtYB7xkYeejcdVEpqfvf/ZOXPDp8x2Wg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.6.2.tgz",
+      "integrity": "sha512-JpCHpMdxo680yEkb6U1y3wrhZGHltgCnaQ8Zj6yKE8KE0BTLVl9UQGisP5De1wlFn4GtpPCf7WtQ8+M5aqq3YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "9.6.0"
+        "@cspell/cspell-types": "9.6.2"
       }
     },
     "node_modules/debug": {
@@ -1718,9 +1745,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.27",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
-      "integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+      "version": "0.16.28",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -2684,9 +2711,9 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.6.0.tgz",
-      "integrity": "sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.6.1.tgz",
+      "integrity": "sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "devDependencies": {
     "bats": "^1.13.0",
-    "cspell": "^9.6.0",
+    "cspell": "^9.6.2",
     "markdownlint-cli": "^0.47.0",
-    "sort-package-json": "^3.6.0",
+    "sort-package-json": "^3.6.1",
     "yaml-lint": "^1.7.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,5 @@
 {
     "extends": [
-        "config:recommended"
-    ],
-    "dependencyDashboard": true,
-    "pre-commit": {
-        "enabled": true
-    },
-    "packageRules": [
-        {
-            "matchManagers": [
-                "github-actions"
-            ],
-            "groupName": "renovate: github-actions"
-        },
-        {
-            "matchManagers": [
-                "pre-commit"
-            ],
-            "groupName": "renovate: pre-commit"
-        },
-        {
-            "matchDatasources": [
-                "docker"
-            ],
-            "groupName": "renovate: docker"
-        },
-        {
-            "matchDatasources": [
-                "npm"
-            ],
-            "groupName": "renovate: npm"
-        }
+        "github>ministryofjustice/devsecops-actions"
     ]
 }


### PR DESCRIPTION
# Introduction :pencil2:

Ensure `Renovate` and `Dependabot` both have minimum age to wait before raising a PR.

## Resolution :heavy_check_mark:

* Updated `renovate.json` and `dependabot.yml` configuration files.

## Miscellaneous :heavy_plus_sign:

* Dependencies updates.