### PR TITLE
Adding support for extra env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,14 @@
-repos:
-  - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: 25557b9b5509fb3026eb212b34f0f98ae1f47584
-    hooks:
-      - id: baseline
+repos: 
+  -  repo: local
+     hooks:
+        - id: baseline
+          name: "MoJ secret scanner"
+          description: "Scans staged changes for hardcoded secrets using gitleaks."
+          entry: hooks/gitleaks/run.sh
+          language: script
+          pass_filenames: false
+          always_run: true
+          verbose: true
+          stages:
+            - pre-commit
 
-  - repo: local
-    hooks:
-      - id: pre-commit-validate-manifest
-        name: Validate pre-commit hook manifest
-        entry: pre-commit validate-manifest
-        pass_filenames: false
-        language: system
-
-      - id: pre-commit-validate-config
-        name: Validate pre-commit config
-        entry: pre-commit validate-config
-        pass_filenames: false
-        language: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Features
 
+* Re-introduce `GITLEAKS_CONFIGURATION_FILE` environment variable as an alias for `GITLEAKS_CONFIG`, restoring backwards compatibility for HMPPS consumers
+* Add `GITLEAKS_IGNORE_FILE` environment variable support when using a custom config — defaults to `.gitleaksignore`, allowing teams to suppress known false positives by committing a `.gitleaksignore` file to their repository. (This ignores missing files so should be backwards compatible)
+
+## [2.0.0]
+
+### Features
+
 * Remove Docker entirely — hook now runs as `language: script` using a host-installed gitleaks binary
 * Add `.gitleaks.override.toml` extension mechanism for additive team-level rules
 * Switch from `gitleaks git` / `gitleaks detect` via `scripts/scan.sh` to `gitleaks git --pre-commit --staged` — reports file name and line number for each finding

--- a/hooks/gitleaks/run.sh
+++ b/hooks/gitleaks/run.sh
@@ -9,8 +9,13 @@ if ! command -v gitleaks >/dev/null 2>&1; then
     exit 1
 fi
 
+if [ -n "${GITLEAKS_CONFIGURATION_FILE:-}" ]; then
+    GITLEAKS_CONFIG="${GITLEAKS_CONFIGURATION_FILE}"
+fi
+
 if [ -n "${GITLEAKS_CONFIG:-}" ] || [ -n "${GITLEAKS_CONFIG_TOML:-}" ]; then
-    exec gitleaks git --pre-commit --staged --no-banner --redact --verbose --exit-code 1
+    exec gitleaks git --pre-commit --staged --no-banner --redact --verbose --exit-code 1 \
+        --gitleaks-ignore-path "${GITLEAKS_IGNORE_FILE:-.gitleaksignore}"
 fi
 
 BASE_CONFIG="${GITLEAKS_BASE_CONFIG:-$BUNDLED_CONFIG}"


### PR DESCRIPTION
This is to remain backwards compatible with HMPPS projects 

Including:
* Re-introduce `GITLEAKS_CONFIGURATION_FILE` environment variable as an alias for `GITLEAKS_CONFIG`, restoring backwards compatibility for HMPPS consumers
* Add `GITLEAKS_IGNORE_FILE` environment variable support when using a custom config — defaults to `.gitleaksignore`, allowing teams to suppress known false positives by committing a `.gitleaksignore` file to their repository. (This ignores missing files so should be backwards compatible)

